### PR TITLE
feat: 添加自定义 Docker 端口功能

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,10 @@ DATABASE_URL=
 AUTH_SECRET=PKqQmr74pyUXLR18kx85is9yXguIinaJ40DrOBim+Tg=
 # 管理员授权码，安装完成后，凭此值访问 /setup 页设置管理员账号
 ADMIN_CODE=11223344
+# 本地开发时，用于访问服务器的端口，生产环境请结合 nginx 等反向代理设置
+HOST_PORT=3000
 # 生产环境设置为正式域名
-NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_URL=http://localhost:${HOST_PORT}
 AUTH_TRUST_HOST=true
 
 # 是否开启邮箱登录，开启值设为 ON，关闭时修改为 OFF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: hivechat
     image: hivenexus/hivechat:0.0.4
     ports:
-      - "3000:3000"
+      - "${HOST_PORT}:3000"
     depends_on:
       - db
     environment:


### PR DESCRIPTION
- 将原来 docker-compose.yml 中的本地端口 3000 提取到环境变量中
- 环境变量文件中增加 HOST_PORT参数，默认值保持 3000
- 支持实际部署时便捷调整发布端口，以免和已有服务端口冲突