### PR TITLE
fix: 修复代码块中 Ant Design message API 上下文问题

### DIFF
--- a/app/chat/layout.tsx
+++ b/app/chat/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 import App from "@/app/components/App";
 import ChatPrepare from "@/app/components/ChatPrepare";
+import { App as AntdApp } from 'antd';
 
 export default function ChatLayout({
   children,
@@ -11,7 +12,9 @@ export default function ChatLayout({
   return (
     <div className="flex flex-col h-dvh">
       <ChatPrepare />
-      <App>{children}</App>
+      <AntdApp>
+        <App>{children}</App>
+      </AntdApp>
     </div>
   )
 }

--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from "react";
-import { CopyOutlined, CheckOutlined } from "@ant-design/icons";
+import React from "react";
+import { CopyOutlined } from "@ant-design/icons";
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { Button, Tooltip, message } from "antd";
+import { Button, Tooltip, App} from "antd";
 
 const CodeBlock: React.FC<{ children: React.ReactNode; language: string }> = ({ children, language }) => {
-  const [messageApi, contextHolderMessage] = message.useMessage();
+  const { message } = App.useApp();
   const reactNodeToText = (node: React.ReactNode): string => {
     if (typeof node === 'string' || typeof node === 'number' || typeof node === 'boolean') {
       return String(node);
@@ -24,12 +24,11 @@ const CodeBlock: React.FC<{ children: React.ReactNode; language: string }> = ({ 
 
   return (
     <>
-      {contextHolderMessage}
       <div className="bg-slate-200 -mt-4 -mx-4 mb-4 py-2 px-4 flex justify-between items-center">
         <span className="text-xs text-gray-500">{language}</span>
         <CopyToClipboard text={reactNodeToText(children)}
           onCopy={() => {
-            messageApi.success('复制成功');
+            message.success('复制成功');
           }}>
           <Tooltip title="复制">
             <Button type="text" size='small'>


### PR DESCRIPTION
- 修复 CodeBlock 组件中使用 message API 导致的 NotFoundErrorBoundary 错误
- 使用 App.useApp() 获取正确的 message 上下文
- 在布局组件中添加 AntdApp 提供全局上下文
- 解决 "Static function can not consume context like dynamic theme" 警告

关联 issue #73 